### PR TITLE
Change search suggestion provider from Google to Bing

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -45,17 +45,18 @@ $(function() {
    source:[
     function( q,add ){
       $.ajax({
-          url: 'http://suggestqueries.google.com/complete/search',
-          jsonp: 'callback',
+          url: "http://api.bing.net/qson.aspx",
           dataType: 'jsonp',
+          jsonp: "JsonCallback",
           data: {
-            q: q+pair(q),
+            JsonType: "callback",
+            Query: q+pair(q),
             client: 'chrome'
           },
           success: function( response ) {
             console.log( response ); // server response
-            response[1].length = 4;
-            add(response[1]);
+            response.SearchSuggestion.Section.length = 4;
+            add(response.SearchSuggestion.Section.map(function(d){return d.Text;}));
           }
       });
     }


### PR DESCRIPTION
Single Google's public access to autocomplete is going away on 2015-08-10, change the provider to Bing who hasn't made any such announcement.  Lightly tested but seems to be working correctly.
